### PR TITLE
Remove use of deprecated array access syntax

### DIFF
--- a/src/Ajgl/Doctrine/DBAL/Types/ArrayTypeAbstract.php
+++ b/src/Ajgl/Doctrine/DBAL/Types/ArrayTypeAbstract.php
@@ -103,10 +103,10 @@ abstract class ArrayTypeAbstract extends Type
         }
         if ('{}' != $input) {
             do {
-                if ('{' != $input{$offset}) {
+                if ('{' != $input[$offset]) {
                     preg_match("/(\\{?\"([^\"\\\\]|\\\\.)*\"|[^,{}]+)+([,}]+)/", $input, $match, 0, $offset);
                     $offset += strlen($match[0]);
-                    $output[] = ( '"' != $match[1]{0} ? $match[1] : stripcslashes(substr($match[1], 1, -1)) );
+                    $output[] = ( '"' != $match[1][0] ? $match[1] : stripcslashes(substr($match[1], 1, -1)) );
                     if ('},' == $match[3]) {
                         return $offset;
                     }


### PR DESCRIPTION
`$foo{1}` syntax for accessing array elements [was deprecated in PHP 7.4](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace). There were just two occurrences which i replaced by square brackets.